### PR TITLE
Add a mybinder environment for demonstration

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,6 @@
+channels:
+- conda-forge
+dependencies:
+- anywidget
+- esbuild
+- jupyterlab

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,2 @@
+#!/bin/bash
+pip install .


### PR DESCRIPTION
As I got confused by the version on `pypi` being outdated, I builded a mybinder environment for people to test the package in their browser:
[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jan-janssen/ipyreactflow/binder?labpath=hi.ipynb)

Fixes https://github.com/kolibril13/ipyreactflow/issues/1